### PR TITLE
Fix arrays causing no effect statement error

### DIFF
--- a/source/earcutd.d
+++ b/source/earcutd.d
@@ -45,7 +45,7 @@ struct Earcut(N, Polygon) {
     } else
         static assert(0, typeof(Polygon).stringof ~ " type is not supported.");
     
-    static if(__traits(compiles, { VecPoint vp; vp[0]; })){
+    static if(__traits(compiles, { VecPoint vp; cast(void) vp[0]; })){
         alias Point = typeof(VecPoint.init[0]);
     } else static if (isRandomAccessRange!VecPoint){
         alias ASeq2 = TemplateArgsOf!VecPoint;


### PR DESCRIPTION
In D, a program will not compile if the compiler believes a statement can have no effect. Accessing an array element through an index (`vp[0]`) is one of those cases. 